### PR TITLE
#15 - 로그인 컨트롤러 테스트 + 시큐리티 설정을 컨트롤러 테스트에 반영

### DIFF
--- a/project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -1,10 +1,12 @@
 package com.fastcampus.projectboard.controller;
 
+import com.fastcampus.projectboard.config.SecurityConfig;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -12,6 +14,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 게시글")
+@Import(SecurityConfig.class)
 @WebMvcTest(ArticleController.class)
 class ArticleControllerTest {
 

--- a/project-board/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
+++ b/project-board/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
@@ -1,0 +1,39 @@
+package com.fastcampus.projectboard.controller;
+
+import com.fastcampus.projectboard.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("View 컨트롤러 - 인증")
+@Import(SecurityConfig.class)
+@WebMvcTest
+public class AuthControllerTest {
+
+    private final MockMvc mvc;
+
+    public AuthControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+
+    @DisplayName("[view][GET] 로그인 페이지 - 정상 호출")
+    @Test
+    public void givenNothing_whenTryingToLogIn_thenReturnsLogInView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/login"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+    }
+
+}


### PR DESCRIPTION
스프링 시큐리티가 자동 생성해준 `/login` 컨트롤러를 테스트.
그리고 모든 컨트롤러가 시큐리티 설정을 부를 수 있도록
`@Import` 추가