### PR TITLE
[고도화] MySQL -> PostgreSQL

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/project-board/src/main/resources/application.yaml
+++ b/project-board/src/main/resources/application.yaml
@@ -9,10 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
+    url: jdbc:postgresql://localhost:5432/board
     username: kjh
     password: "!@mysori0825"
-    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.

This closes #50 